### PR TITLE
Fix running composer scripts for plugin download

### DIFF
--- a/deploy-hosts.yml
+++ b/deploy-hosts.yml
@@ -3,6 +3,7 @@
     - app
   port: 22
   forwardAgent: true
+  composer_options: install --verbose --prefer-dist --no-progress --no-interaction --no-dev --optimize-autoloader --no-scripts
   sshOptions:
     UserKnownHostsFile: /dev/null
     StrictHostKeyChecking: no

--- a/deploy-shopware.php
+++ b/deploy-shopware.php
@@ -115,7 +115,7 @@ task(
                      'k10r/deployment:1.2.0',
                  ] as $dependency) {
             run(
-                "cd {{shopware_public_path}} && {{bin/composer}} require --optimize-autoloader --prefer-dist --no-ansi --update-no-dev {$dependency}"
+                "cd {{shopware_public_path}} && {{bin/composer}} require --optimize-autoloader --prefer-dist --no-ansi --update-no-dev --no-scripts {$dependency}"
             );
         }
     }


### PR DESCRIPTION
Solves #3 

When requiring our plugins via composer, Shopware 5.?+ wants to run some building scripts which are missing from the downloaded ZIP archive.